### PR TITLE
Add "RangerCurrentFile" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ let g:ranger_explorer_keymap_vsplit  = '<C-v>'
 
 #### Keymap on Vim
 
-Add following keymap to `~/.vimrc`
+Add following keymap to `~/.vimrc` (Example keymap)
 ```vim
+nnoremap <silent><Leader>n :RangerOpenCurrentFile<CR>
 nnoremap <silent><Leader>c :RangerOpenCurrentDir<CR>
 nnoremap <silent><Leader>f :RangerOpenProjectRootDir<CR>
 ```

--- a/autoload/ranger_explorer.vim
+++ b/autoload/ranger_explorer.vim
@@ -22,11 +22,20 @@ function! ranger_explorer#open(path)
     return
   endif
 
-  let command = 'ranger --choosefile=' . s:path_file . ' ' . a:path
-        \ . ' --cmd="' . s:edit    . '"'
-        \ . ' --cmd="' . s:tabedit . '"'
-        \ . ' --cmd="' . s:split   . '"'
-        \ . ' --cmd="' . s:vsplit  . '"'
+  if isdirectory(a:path)
+    let command = 'ranger --choosefile=' . s:path_file . ' ' . a:path
+          \ . ' --cmd="' . s:edit    . '"'
+          \ . ' --cmd="' . s:tabedit . '"'
+          \ . ' --cmd="' . s:split   . '"'
+          \ . ' --cmd="' . s:vsplit  . '"'
+  else
+    let command = 'ranger --choosefile=' . s:path_file
+          \ . ' --selectfile="' . a:path . '"'
+          \ . ' --cmd="' . s:edit    . '"'
+          \ . ' --cmd="' . s:tabedit . '"'
+          \ . ' --cmd="' . s:split   . '"'
+          \ . ' --cmd="' . s:vsplit  . '"'
+  endif
 
   if has('nvim')
     let rangerCallback = { 'name': 'ranger' }

--- a/autoload/ranger_explorer.vim
+++ b/autoload/ranger_explorer.vim
@@ -22,7 +22,7 @@ function! ranger_explorer#open(path)
     return
   endif
 
-  let command = 'ranger --choosefile=' . s:path_file . ' ' . a:path 
+  let command = 'ranger --choosefile=' . s:path_file . ' ' . a:path
         \ . ' --cmd="' . s:edit    . '"'
         \ . ' --cmd="' . s:tabedit . '"'
         \ . ' --cmd="' . s:split   . '"'
@@ -55,6 +55,11 @@ endfunction
 function! ranger_explorer#open_current_dir() abort
   let current_dir = expand('%:p:h')
   :call ranger_explorer#open(current_dir)
+endfunction
+
+function! ranger_explorer#open_current_file() abort
+  let current_file = expand('%')
+  :call ranger_explorer#open(current_file)
 endfunction
 
 function! ranger_explorer#open_with_edit(path) abort

--- a/plugin/ranger_explorer.vim
+++ b/plugin/ranger_explorer.vim
@@ -15,6 +15,9 @@ let g:loaded_netrwPlugin = 'disable'
 let s:save_cpoptions = &cpoptions
 set cpoptions&vim
 
+command! RangerOpenCurrentFile
+\    call ranger_explorer#open_current_file()
+
 command! RangerOpenCurrentDir
 \    call ranger_explorer#open_current_dir()
 


### PR DESCRIPTION
## Description

I'm currently using [ranger.vim](https://github.com/francoiscabrol/ranger.vim).

ranger.vim has `:RangerCurrentFile` command.

This command uses the `--choosefile` to specify the "current file".

I use `:RangerCurrentFile` a lot.

Since `ranger-explorer.vim` doesn't have similar functionality, we've added `:RangerOpenCurrentFile`.

## Demo

![ranger-explorer-pr](https://user-images.githubusercontent.com/188642/92862223-67caa800-f435-11ea-859c-0c85d8a19afd.gif)
